### PR TITLE
Remove display after loading.

### DIFF
--- a/src/css/loading.less
+++ b/src/css/loading.less
@@ -16,6 +16,7 @@
   bottom: 0px;
   left: 0px;
   opacity : 1;
+  display: block;
   margin: auto;
   transform: rotate(15deg);
   animation: rotation 2.4s linear infinite, fadein 1s;
@@ -29,6 +30,7 @@
 .done {
   animation: fadeout 2s;
   animation-fill-mode: forwards;
+  display: none;
 }
 
 .loading svg {


### PR DESCRIPTION
displayが残り続けてスマホの時に料金のfocusの邪魔をしてた為